### PR TITLE
Formatting cleanups for README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,39 @@ Jsonnet language, from its most basic features to its powerful object model, pun
 
 Caveat: Note that Jsonnet unparses JSON in a simple way. In particular, it alphabetically reorders object fields in its output. This is natural and compatible with JSON, since if order is meaningful, an array of pairs should be used instead of an object. Also, unparsing JSON using a canonical ordering of field names makes it possible to use diff to compare outputs. However, the example output on this page has been manually re-ordered in order to allow easier visual comparison to the given input. The whitespace of the output has also been tweaked to make it fit more neatly on the page. So, if you run these examples yourself, the output might be different (but equivalent).
 
-The git of Google JsonNet:  https://github.com/google/jsonnet
+For more information on Jsonnet, please see:
+
+* [Jsonnet home page](https://jsonnet.org)
+* [Jsonnet git repo](https://github.com/google/jsonnet)
 
 ### Install Jsonnet for PHP
+
+The pecl package is:  http://pecl.php.net/package/jsonnet
+
+To install Jsonnet, run:
+
 ```
-The pecl package is :  http://pecl.php.net/package/jsonnet
+pecl install jsonnet
+```
 
-    pecl install jsonnet
+or:
 
-or
+```
+wget -O Jsonnet.Latest.tar.gz https://pecl.php.net/get/jsonnet
+mkdir Jsonnet-PHP && tar -xzvf Jsonnet.Latest.tar.gz -C ./Jsonnet-PHP
+cd Jsonnet-PHP/Jsonnet-1.0.0
 
-
-    wget -O JsonNet.Latest.tar.gz https://pecl.php.net/get/jsonnet
-    mkdir JsonNet-PHP && tar -xzvf JsonNet.Latest.tar.gz -C ./JsonNet-PHP
-    cd JsonNet-PHP/JsonNet-1.0.0
-
-    phpize
-    ./configure
-    make && make install
-
+phpize
+./configure
+make && make install
 ```
 
 
 ### Simple Syntax Improvements
 
 #### Input (Jsonnet)
-```
+
+```jsonnet
 {
     cocktails: {
         // Ingredient quantities are in fluid ounces.
@@ -57,11 +64,11 @@ or
         },
     }
 }
-
 ```
 
 #### Output (JSON)
-````
+
+```json
 {
     "cocktails": {
 
@@ -87,50 +94,50 @@ or
         }
     }
 }
-````
+```
 
 ### Demo of PHP
+
 ```php
+Jsonnet::evaluateFile('bar_menu.1.jsonnet');
 
-    JsonNet::evaluateFile('bar_menu.1.jsonnet');
-
-    $Snippet = '
-    {
-        cocktails: {
-            // Ingredient quantities are in fluid ounces.
-            "Tom Collins": {
-                ingredients: [
-                    { kind: "Farmers Gin", qty: 1.5 },
-                    { kind: "Lemon", qty: 1 },
-                    { kind: "Simple Syrup", qty: 0.5 },
-                    { kind: "Soda", qty: 2 },
-                    { kind: "Angostura", qty: "dash" },
-                ],
-                garnish: "Maraschino Cherry",
-                served: "Tall",
-            },
-            Manhattan: {
-                ingredients: [
-                    { kind: "Rye", qty: 2.5 },
-                    { kind: "Sweet Red Vermouth", qty: 1 },
-                    { kind: "Angostura", qty: "dash" },
-                ],
-                garnish: "Maraschino Cherry",
-                served: "Straight Up",
-            },
-        }
+$Snippet = '
+{
+    cocktails: {
+        // Ingredient quantities are in fluid ounces.
+        "Tom Collins": {
+            ingredients: [
+                { kind: "Farmers Gin", qty: 1.5 },
+                { kind: "Lemon", qty: 1 },
+                { kind: "Simple Syrup", qty: 0.5 },
+                { kind: "Soda", qty: 2 },
+                { kind: "Angostura", qty: "dash" },
+            ],
+            garnish: "Maraschino Cherry",
+            served: "Tall",
+        },
+        Manhattan: {
+            ingredients: [
+                { kind: "Rye", qty: 2.5 },
+                { kind: "Sweet Red Vermouth", qty: 1 },
+                { kind: "Angostura", qty: "dash" },
+            ],
+            garnish: "Maraschino Cherry",
+            served: "Straight Up",
+        },
     }
-    ';
+}
+';
 
-    var_dump(JsonNet::evaluateSnippet($Snippet));
-
+var_dump(Jsonnet::evaluateSnippet($Snippet));
 ```
 
 ### PHP Re Result
+
 ```
 /usr/local/php/php-7.0.6-zts-debug/bin/php --re jsonnet
 
-Extension [ <persistent> extension #40 JsonNet version v1.3.0 ] {
+Extension [ <persistent> extension #40 Jsonnet version v1.3.0 ] {
 
   - Constants [2] {
     Constant [ string JSONNET_PHP_VERSION ] { v1.3.0 }
@@ -138,14 +145,14 @@ Extension [ <persistent> extension #40 JsonNet version v1.3.0 ] {
   }
 
   - Functions {
-    Function [ <internal:JsonNet> function jsonnet_get_version ] {
+    Function [ <internal:Jsonnet> function jsonnet_get_version ] {
     }
-    Function [ <internal:JsonNet> function jsonnet_get_author ] {
+    Function [ <internal:Jsonnet> function jsonnet_get_author ] {
     }
   }
 
   - Classes [1] {
-    Class [ <internal:JsonNet> class JsonNet ] {
+    Class [ <internal:Jsonnet> class Jsonnet ] {
 
       - Constants [0] {
       }
@@ -154,28 +161,28 @@ Extension [ <persistent> extension #40 JsonNet version v1.3.0 ] {
       }
 
       - Static methods [4] {
-        Method [ <internal:JsonNet> static public method evaluateFile ] {
+        Method [ <internal:Jsonnet> static public method evaluateFile ] {
 
           - Parameters [1] {
             Parameter #0 [ <required> $file_path ]
           }
         }
 
-        Method [ <internal:JsonNet> static public method evaluateSnippet ] {
+        Method [ <internal:Jsonnet> static public method evaluateSnippet ] {
 
           - Parameters [1] {
             Parameter #0 [ <required> $snippet_string ]
           }
         }
 
-        Method [ <internal:JsonNet> static public method fmtFile ] {
+        Method [ <internal:Jsonnet> static public method fmtFile ] {
 
           - Parameters [1] {
             Parameter #0 [ <required> $file_path ]
           }
         }
 
-        Method [ <internal:JsonNet> static public method fmtSnippet ] {
+        Method [ <internal:Jsonnet> static public method fmtSnippet ] {
 
           - Parameters [1] {
             Parameter #0 [ <required> $snippet_string ]
@@ -187,10 +194,10 @@ Extension [ <persistent> extension #40 JsonNet version v1.3.0 ] {
       }
 
       - Methods [2] {
-        Method [ <internal:JsonNet, ctor> public method __construct ] {
+        Method [ <internal:Jsonnet, ctor> public method __construct ] {
         }
 
-        Method [ <internal:JsonNet, dtor> public method __destruct ] {
+        Method [ <internal:Jsonnet, dtor> public method __destruct ] {
         }
       }
     }
@@ -199,7 +206,8 @@ Extension [ <persistent> extension #40 JsonNet version v1.3.0 ] {
 ```
 
 ### CodeTips
-```
+
+```php
 <?php
 /**
  * @author neeke@php.net
@@ -225,16 +233,16 @@ function jsonnet_get_author()
     return JSONNET_PHP_AUTHOR;
 }
 
-class JsonNet
+class Jsonnet
 {
     public function __construct()
     {
-        #JsonNet init
+        #Jsonnet init
     }
 
     public function __destruct()
     {
-        #JsonNet destroy
+        #Jsonnet destroy
     }
 
     /**
@@ -245,7 +253,7 @@ class JsonNet
      */
     static public function evaluateFile($file_path)
     {
-        throw new Exception('JsonNet::evaluateFile #error', CODE_ERROR);
+        throw new Exception('Jsonnet::evaluateFile #error', CODE_ERROR);
 
         return array();
     }
@@ -258,7 +266,7 @@ class JsonNet
      */
     static public function evaluateSnippet($snippet_string)
     {
-        throw new Exception('JsonNet::evaluateSnippet #error', CODE_ERROR);
+        throw new Exception('Jsonnet::evaluateSnippet #error', CODE_ERROR);
 
         return array();
     }
@@ -271,7 +279,7 @@ class JsonNet
      */
     static public function fmtFile($file_path)
     {
-        throw new Exception('JsonNet::fmtFile #error', CODE_ERROR);
+        throw new Exception('Jsonnet::fmtFile #error', CODE_ERROR);
 
         return array();
     }
@@ -284,7 +292,7 @@ class JsonNet
      */
     static public function fmtSnippet($snippet_string)
     {
-        throw new Exception('JsonNet::fmtSnippet #error', CODE_ERROR);
+        throw new Exception('Jsonnet::fmtSnippet #error', CODE_ERROR);
 
         return array();
     }


### PR DESCRIPTION
* Fixed capitalization: JsonNet -> Jsonnet
* Added language directive for syntax highlighting code snippets
* Removed extra indent whitespace around code samples for readability
* Minor wording changes for readability
* Added link to Jsonnet homepage for more info